### PR TITLE
removed OrgPreferenceSettings for Spring 20

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,11 +1,13 @@
 {
     "orgName": "LWC Workshop",
     "edition": "Developer",
-    "hasSampleData": "true",
+    "hasSampleData": true,
     "settings": {
-        "orgPreferenceSettings": {
-            "s1DesktopEnabled": true,
-            "s1EncryptedStoragePref2": false
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "mobileSettings": {
+            "enableS1EncryptedStoragePref2": false
         }
     }
 }


### PR DESCRIPTION
Fixes org config file by removing OrgPreferenceSettings.

See issue #6 

Once updated, I tested and was able to create a new org, push, assign permset, and generate data from the "Import Data" tab. 